### PR TITLE
Fix #39 Constantly uses 100% of cpu

### DIFF
--- a/una-updater
+++ b/una-updater
@@ -19,6 +19,7 @@ _ui() {
 while true; do
     source /etc/una/config &>/dev/null
     if [[ "${auto_update}" == "true" ]]; then
-        _ui; sleep "${update_check_gap}"
+        _ui
     fi
+    sleep "${update_check_gap}"
 done


### PR DESCRIPTION
This change moves the `sleep "${update_check_gap}"` instruction outside the `auto_update` check preventing the infinite loop from consuming a lot of CPU resources.