### PR TITLE
Update link README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ bash <(curl -fsL https://github.com/AFK-OS/una/raw/main/install.sh)
 - [x] Support for auto-completions.
 - [x] Support for cloning packages from the MPR, separate from installation.
 - [x] Auto updater.
-- [x] Implement all the features listed on https://docs.makedeb.org/mpr/list-of-mpr-helpers/.
+- [x] Implement all the features listed on https://github.com/makedeb/mist/tree/main?tab=readme-ov-file#mist.
 - [x] Install `-git` package if main package doesn't exist.
 - [x] Compatibility with other MPR helpers.
 - [x] Support for installing multiple packages together.


### PR DESCRIPTION
* Link to former link `https://docs.makedeb.org/mpr/list-of-mpr-helpers/` is now not found in `makedeb` docs
    * Mist [page](https://docs.makedeb.org/using-the-mpr/mist-the-mpr-cli/) is currently closest match among `makdedeb` doc pages
    * However, after looking at the latest [snapshot ](https://web.archive.org/web/20220324121421/https://docs.makedeb.org/mpr/list-of-mpr-helpers/) from March 2022, the features explicitly listed are in the first section of Mist's [README](https://github.com/makedeb/mist/tree/main?tab=readme-ov-file#mis)